### PR TITLE
update batching/sending logic, pull out logger methods to logger.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To specify additional logging driver options, you can use the `--log-opt NAME=VA
 | `sumo-insecure-skip-verify` | No        | false         | Ignore server certificate validation. Boolean.
 | `sumo-root-ca-path`         | No        |               | Set the path to a custom root certificate.
 | `sumo-server-name`          | No        |               | Name used to validate the server certificate. By default, uses hostname of the `sumo-url`.
-| `sumo-queue-size`           | No        | 500           | The maximum number of log batches of size sumo-batch-size we can store in memory in the event of network failure, before we begin dropping batches.
+| `sumo-queue-size`           | No        | 100           | The maximum number of log batches of size sumo-batch-size we can store in memory in the event of network failure, before we begin dropping batches.
 
 ```bash
 $ docker run --log-driver=sumologic \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To specify additional logging driver options, you can use the `--log-opt NAME=VA
 | `sumo-insecure-skip-verify` | No        | false         | Ignore server certificate validation. Boolean.
 | `sumo-root-ca-path`         | No        |               | Set the path to a custom root certificate.
 | `sumo-server-name`          | No        |               | Name used to validate the server certificate. By default, uses hostname of the `sumo-url`.
-| `sumo-queue-size`           | No        | 100           | The maximum number of log batches of size sumo-batch-size we can store in memory in the event of network failure, before we begin dropping batches.
+| `sumo-queue-size`           | No        | 100           | The maximum number of log batches of size `sumo-batch-size` we can store in memory in the event of network failure, before we begin dropping batches. Thus in the worst case, the plugin will use `sumo-batch-size` * `sumo-queue-size` bytes of memory per container (default 100 MB).
 
 ```bash
 $ docker run --log-driver=sumologic \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To specify additional logging driver options, you can use the `--log-opt NAME=VA
 | `sumo-insecure-skip-verify` | No        | false         | Ignore server certificate validation. Boolean.
 | `sumo-root-ca-path`         | No        |               | Set the path to a custom root certificate.
 | `sumo-server-name`          | No        |               | Name used to validate the server certificate. By default, uses hostname of the `sumo-url`.
-| `sumo-queue-size`           | No        | 100           | The maximum number of log batches of size sumo-batch-size we can store in memory in the event of network failure, before we begin dropping batches.
+| `sumo-queue-size`           | No        | 500           | The maximum number of log batches of size sumo-batch-size we can store in memory in the event of network failure, before we begin dropping batches.
 
 ```bash
 $ docker run --log-driver=sumologic \

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "description": "Sumo Logic logging driver",
-  "documentation": "https://github.com/SumoLogic/docker-logging-driver/",
+  "documentation": "https://github.com/SumoLogic/sumologic-docker-logging-driver",
   "entrypoint": ["/usr/bin/docker-logging-driver"],
   "network": {
     "type": "host"

--- a/config.json
+++ b/config.json
@@ -7,6 +7,6 @@
   },
   "interface": {
     "types": ["docker.logdriver/1.0"],
-    "socket": "sumo-log-driver.sock"
+    "socket": "sumologic.sock"
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "description": "Sumo Logic logging driver",
-  "documentation": "<insert link here>",
+  "documentation": "https://github.com/SumoLogic/docker-logging-driver/",
   "entrypoint": ["/usr/bin/docker-logging-driver"],
   "network": {
     "type": "host"

--- a/driver.go
+++ b/driver.go
@@ -11,6 +11,7 @@ import (
 
   "github.com/docker/docker/daemon/logger"
   "github.com/pkg/errors"
+  "github.com/sirupsen/logrus"
   "github.com/tonistiigi/fifo"
 )
 
@@ -18,7 +19,7 @@ const (
   logOptUrl = "sumo-url"
 
   defaultSendingIntervalMs = 2000 * time.Millisecond
-  defaultQueueSizeItems = 500
+  defaultQueueSizeItems = 100
   defaultBatchSizeBytes = 1000000
 
   fileMode = 0700
@@ -107,6 +108,7 @@ func (sumoDriver *sumoDriver) StopLogging(file string) error {
   sumoDriver.mu.Lock()
   sumoLogger, exists := sumoDriver.loggers[file]
   if exists {
+    logrus.Info("stopping logging driver for closed container.")
     sumoLogger.inputFile.Close()
     delete(sumoDriver.loggers, file)
   }

--- a/driver_test.go
+++ b/driver_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
   "context"
+  "io/ioutil"
   "os"
   "strconv"
   "testing"
 
   "github.com/docker/docker/daemon/logger"
+  "github.com/sirupsen/logrus"
   "github.com/stretchr/testify/assert"
   "github.com/tonistiigi/fifo"
   "golang.org/x/sys/unix"
@@ -29,6 +31,7 @@ var (
 )
 
 func TestDrivers (t *testing.T) {
+  logrus.SetOutput(ioutil.Discard)
   testLoggersCount := 100
 
   for i := 0; i < testLoggersCount; i++ {

--- a/driver_test.go
+++ b/driver_test.go
@@ -17,7 +17,7 @@ const (
   filePath1 = "/tmp/test1"
   filePath2 = "/tmp/test2"
 
-  httpSourceUrl = "https://example.org"
+  testHttpSourceUrl = "https://example.org"
 
   testSource = "sumo-test"
   testTime = 1234567890
@@ -40,26 +40,26 @@ func TestDrivers (t *testing.T) {
 
   info := logger.Info{
     Config: map[string]string{
-      logOptUrl: httpSourceUrl,
+      logOptUrl: testHttpSourceUrl,
     },
     ContainerID: "containeriid",
   }
 
-  t.Run("startLoggingInternal", func(t *testing.T) {
+  t.Run("NewSumoLogger", func(t *testing.T) {
     testSumoDriver := newSumoDriver()
     assert.Equal(t, 0, len(testSumoDriver.loggers), "there should be no loggers when the driver is initialized")
 
-    testSumoLogger1, err := testSumoDriver.startLoggingInternal(filePath1, info)
+    testSumoLogger1, err := testSumoDriver.NewSumoLogger(filePath1, info)
     assert.Nil(t, err)
     assert.Equal(t, 1, len(testSumoDriver.loggers), "there should be one logger after calling StartLogging on driver")
     assert.Equal(t, info.Config[logOptUrl], testSumoLogger1.httpSourceUrl, "http source url should be configured correctly")
 
-    _, err = testSumoDriver.startLoggingInternal(filePath1, info)
+    _, err = testSumoDriver.NewSumoLogger(filePath1, info)
     assert.Error(t, err, "trying to call StartLogging for filepath that already exists should return error")
     assert.Equal(t, 1, len(testSumoDriver.loggers),
       "there should still be one logger after calling StartLogging for filepath that already exists")
 
-    testSumoLogger2, err := testSumoDriver.startLoggingInternal(filePath2, info)
+    testSumoLogger2, err := testSumoDriver.NewSumoLogger(filePath2, info)
     assert.Nil(t, err)
     assert.Equal(t, 2, len(testSumoDriver.loggers),
       "there should be two loggers now after calling StartLogging on driver for different filepaths")
@@ -81,7 +81,7 @@ func TestDrivers (t *testing.T) {
     assert.Nil(t, err, "trying to call StopLogging for nonexistent logger should NOT return error")
     assert.Equal(t, 0, len(testSumoDriver.loggers), "no loggers should be changed after calling StopLogging for nonexistent logger")
 
-    _, err = testSumoDriver.startLoggingInternal(filePath1, info)
+    _, err = testSumoDriver.NewSumoLogger(filePath1, info)
     assert.Nil(t, err)
     assert.Equal(t, 1, len(testSumoDriver.loggers), "there should be one logger after calling StartLogging on driver")
 
@@ -94,14 +94,14 @@ func TestDrivers (t *testing.T) {
     assert.Equal(t, 0, len(testSumoDriver.loggers), "calling StopLogging on existing logger should remove the logger")
   })
 
-  t.Run("startLoggingInternal, concurrently", func(t *testing.T) {
+  t.Run("NewSumoLogger, concurrently", func(t *testing.T) {
     testSumoDriver := newSumoDriver()
     assert.Equal(t, 0, len(testSumoDriver.loggers), "there should be no loggers when the driver is initialized")
 
     waitForAllLoggers := make(chan int)
     for i := 0; i < testLoggersCount; i++ {
       go func(i int) {
-        _, err := testSumoDriver.startLoggingInternal(filePath + strconv.Itoa(i + 1), info)
+        _, err := testSumoDriver.NewSumoLogger(filePath + strconv.Itoa(i + 1), info)
         assert.Nil(t, err)
         waitForAllLoggers <- i
       }(i)

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+  "bytes"
+  "encoding/binary"
+  "fmt"
+  "io"
+  "io/ioutil"
+  "net/http"
+  "time"
+
+  "github.com/docker/docker/api/types/plugins/logdriver"
+  protoio "github.com/gogo/protobuf/io"
+  "github.com/sirupsen/logrus"
+)
+
+const (
+  retryInterval = 5 * time.Second
+
+  fileReaderMaxSize = 1e6
+  stringToIntBase = 10
+  stringToIntBitSize = 32
+)
+
+type sumoLog struct {
+  line []byte
+  source string
+  time string
+  isPartial bool
+}
+
+type sumoLogBatch struct {
+  logs []*sumoLog
+  size int
+}
+
+func NewSumoLogBatch() *sumoLogBatch {
+  return &sumoLogBatch{
+    logs: nil,
+    size: 0,
+  }
+}
+
+func (sumoLogBatch *sumoLogBatch) Reset() {
+  sumoLogBatch.logs = nil
+  sumoLogBatch.size = 0
+}
+
+func (sumoLogger *sumoLogger) consumeLogsFromFile() {
+  /* https://github.com/gogo/protobuf/blob/master/io/uint32.go */
+  dec := protoio.NewUint32DelimitedReader(sumoLogger.inputFile, binary.BigEndian, fileReaderMaxSize)
+  defer dec.Close()
+  var log logdriver.LogEntry
+  for {
+    if err := dec.ReadMsg(&log); err != nil {
+      if err == io.EOF {
+        sumoLogger.inputFile.Close()
+        close(sumoLogger.logQueue)
+        return
+      }
+      logrus.Error(err)
+      dec = protoio.NewUint32DelimitedReader(sumoLogger.inputFile, binary.BigEndian, fileReaderMaxSize)
+    }
+    sumoLog := &sumoLog{
+      line: log.Line,
+      source: log.Source,
+      time: time.Unix(0, log.TimeNano).String(),
+      isPartial: log.Partial,
+    }
+    sumoLogger.logQueue <- sumoLog
+    log.Reset()
+  }
+}
+
+func (sumoLogger *sumoLogger) batchLogs() {
+  ticker := time.NewTicker(sumoLogger.sendingInterval)
+  logBatch := NewSumoLogBatch()
+  for {
+    select {
+    case log, open := <-sumoLogger.logQueue:
+      if !open {
+        sumoLogger.logBatchQueue <- logBatch.logs
+        close(sumoLogger.logBatchQueue)
+        return
+      }
+      logBatch.logs = append(logBatch.logs, log)
+      logBatch.size += len(log.line)
+      if logBatch.size >= sumoLogger.batchSize {
+        sumoLogger.pushBatchToQueue(logBatch)
+      }
+    case <-ticker.C:
+      if len(logBatch.logs) > 0 {
+        sumoLogger.pushBatchToQueue(logBatch)
+      }
+    }
+  }
+}
+
+func (sumoLogger *sumoLogger) pushBatchToQueue(logBatch *sumoLogBatch) {
+  select {
+  case sumoLogger.logBatchQueue <- logBatch.logs:
+    logBatch.Reset()
+  default:
+    <-sumoLogger.logBatchQueue
+    logrus.Error(fmt.Errorf("log batch queue full, dropping oldest batch"))
+    sumoLogger.logBatchQueue <- logBatch.logs
+  }
+}
+
+func (sumoLogger *sumoLogger) handleBatchedLogs() {
+  for {
+    logBatch, open := <-sumoLogger.logBatchQueue
+    if !open {
+      return
+    }
+    for {
+      err := sumoLogger.sendLogs(logBatch)
+      if err == nil {
+        time.Sleep(retryInterval)
+      }
+    }
+  }
+}
+
+func (sumoLogger *sumoLogger) sendLogs(logs []*sumoLog) error {
+  var logsBatch bytes.Buffer
+  if err := sumoLogger.writeMessage(&logsBatch, logs); err != nil{
+    return err
+  }
+
+  request, err := http.NewRequest("POST", sumoLogger.httpSourceUrl, bytes.NewBuffer(logsBatch.Bytes()))
+  if err != nil {
+    return err
+  }
+
+  response, err := sumoLogger.httpClient.Do(request)
+  if err != nil {
+    return err
+  }
+
+  defer response.Body.Close()
+  if response.StatusCode != http.StatusOK {
+    body, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+      return err
+    }
+    return fmt.Errorf("%s: Failed to send event: %s - %s", pluginName, response.Status, body)
+  }
+  return nil
+}
+
+func (sumoLogger *sumoLogger) writeMessage(writer io.Writer, logs []*sumoLog) error {
+  for _, log := range logs {
+    if _, err := writer.Write(append(log.line, []byte("\n")...)); err != nil {
+      return err
+    }
+  }
+  return nil
+}

--- a/logger.go
+++ b/logger.go
@@ -131,7 +131,8 @@ func (sumoLogger *sumoLogger) handleBatchedLogs() {
         retryInterval = initialRetryInterval
         break
       }
-      logrus.Info(fmt.Sprintf("Sleeping for %s before retry...", retryInterval.String()))
+      logrus.Info(fmt.Sprintf("%s: Sleeping for %s before retry...",
+        pluginName, retryInterval.String()))
       time.Sleep(retryInterval)
       if retryInterval < maxRetryInterval {
         retryInterval = time.Duration(

--- a/logger.go
+++ b/logger.go
@@ -116,8 +116,9 @@ func (sumoLogger *sumoLogger) handleBatchedLogs() {
     for {
       err := sumoLogger.sendLogs(logBatch)
       if err == nil {
-        time.Sleep(retryInterval)
+        break
       }
+      time.Sleep(retryInterval)
     }
   }
 }

--- a/logger.go
+++ b/logger.go
@@ -31,19 +31,19 @@ type sumoLog struct {
 
 type sumoLogBatch struct {
   logs []*sumoLog
-  size int
+  sizeBytes int
 }
 
 func NewSumoLogBatch() *sumoLogBatch {
   return &sumoLogBatch{
     logs: nil,
-    size: 0,
+    sizeBytes: 0,
   }
 }
 
 func (sumoLogBatch *sumoLogBatch) Reset() {
   sumoLogBatch.logs = nil
-  sumoLogBatch.size = 0
+  sumoLogBatch.sizeBytes = 0
 }
 
 func (sumoLogger *sumoLogger) consumeLogsFromFile() {
@@ -84,8 +84,8 @@ func (sumoLogger *sumoLogger) batchLogs() {
         return
       }
       logBatch.logs = append(logBatch.logs, log)
-      logBatch.size += len(log.line)
-      if logBatch.size >= sumoLogger.batchSize {
+      logBatch.sizeBytes += len(log.line)
+      if logBatch.sizeBytes >= sumoLogger.batchSize {
         sumoLogger.pushBatchToQueue(logBatch)
       }
     case <-ticker.C:

--- a/logger_test.go
+++ b/logger_test.go
@@ -150,13 +150,13 @@ func TestBatchLogs(t *testing.T) {
     }
     go testSumoLogger.batchLogs()
 
-    testLogCount := 100000
+    logCount := 100000
     go func() {
-      for i := 0; i < testLogCount; i++ {
+      for i := 0; i < logCount; i++ {
         testLogQueue <- testSumoLog
       }
     }()
-    for i := 0; i < testLogCount / (testBatchSize / len(testLine)); i++ {
+    for i := 0; i < logCount / (testBatchSize / len(testLine)); i++ {
       testLogBatch := <-testLogBatchQueue
       assert.Equal(t, testBatchSize / len(testLine), len(testLogBatch),
         "should have correct number of logs in a batch")
@@ -198,13 +198,13 @@ func TestBatchLogs(t *testing.T) {
     }
     go testSumoLogger.batchLogs()
 
-    testLogCount := 1000000
+    logCount := 1000000
     go func() {
-      for i := 0; i < testLogCount; i++ {
+      for i := 0; i < logCount; i++ {
         testLogQueue <- testSumoLog
       }
     }()
-    for i := 0; i < testLogCount / (testBatchSize / len(testLine)); i++ {
+    for i := 0; i < logCount / (testBatchSize / len(testLine)); i++ {
       testLogBatch := <-testLogBatchQueue
       assert.Equal(t, testBatchSize / len(testLine), len(testLogBatch),
         "should have correct number of logs in a batch")
@@ -222,7 +222,7 @@ func TestHandleBatchedLogs(t *testing.T) {
   }
   testLogBatch := []*sumoLog{testSumoLog}
 
-  t.Run("status=OK", func (t *testing.T) {
+  t.Run("status=OK, logBatchCount=1", func (t *testing.T) {
     testLogBatchQueue := make(chan []*sumoLog, 4000)
     defer close(testLogBatchQueue)
     testClient := NewMockHttpClient(http.StatusOK)

--- a/logger_test.go
+++ b/logger_test.go
@@ -269,9 +269,9 @@ func TestHandleBatchedLogs(t *testing.T) {
     assert.Equal(t, testLogBatchCount, testClient.requestCount,
       "should have made one HTTP request per batch")
   })
-  
+
   t.Run("status=BadRequest", func (t *testing.T) {
-    testLogBatchQueue := make(chan []*sumoLog, defaultQueueSizeItems)
+    testLogBatchQueue := make(chan *sumoLogBatch, defaultQueueSizeItems)
     defer close(testLogBatchQueue)
     testClient := NewMockHttpClient(http.StatusBadRequest)
     testSumoLogger := &sumoLogger{

--- a/logger_test.go
+++ b/logger_test.go
@@ -234,8 +234,10 @@ func TestHandleBatchedLogs(t *testing.T) {
     go testSumoLogger.handleBatchedLogs()
     testLogBatchQueue <- testLogBatch
     <-testClient.requestReceivedSignal
-    assert.Equal(t, 0, len(testLogBatchQueue))
-    assert.Equal(t, 1, testClient.requestCount)
+    assert.Equal(t, 0, len(testLogBatchQueue),
+      "should have emptied out the batch queue while handling")
+    assert.Equal(t, 1, testClient.requestCount,
+      "should have made only one HTTP request for the batch")
   })
 
   t.Run("status=OK, logBatchCount=1000", func (t *testing.T) {
@@ -258,8 +260,10 @@ func TestHandleBatchedLogs(t *testing.T) {
     for i := 0; i < testLogBatchCount; i++ {
       <-testClient.requestReceivedSignal
     }
-    assert.Equal(t, 0, len(testLogBatchQueue))
-    assert.Equal(t, testLogBatchCount, testClient.requestCount)
+    assert.Equal(t, 0, len(testLogBatchQueue),
+      "should have emptied out the batch queue while handling")
+    assert.Equal(t, testLogBatchCount, testClient.requestCount,
+      "should have made one HTTP request per batch")
   })
 }
 
@@ -312,7 +316,8 @@ func TestSendLogs(t *testing.T) {
 
     err := testSumoLogger.sendLogs(testLogs)
     assert.Nil(t, err, "should be no errors sending logs")
-    assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
+    assert.Equal(t, 1, testClient.requestCount,
+      "should have received one request, logs are batched")
   })
 
   t.Run("testLogCount=1, status=BadRequest", func(t *testing.T) {
@@ -335,7 +340,8 @@ func TestSendLogs(t *testing.T) {
 
     err := testSumoLogger.sendLogs(testLogs)
     assert.NotNil(t, err, "should be an error sending logs")
-    assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
+    assert.Equal(t, 1, testClient.requestCount,
+      "should have received one request, logs are batched")
   })
 
   t.Run("testLogCount=100000, status=BadRequest", func(t *testing.T) {
@@ -361,7 +367,8 @@ func TestSendLogs(t *testing.T) {
 
     err := testSumoLogger.sendLogs(testLogs)
     assert.NotNil(t, err, "should be an error sending logs")
-    assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
+    assert.Equal(t, 1, testClient.requestCount,
+      "should have received one request, logs are batched")
   })
 }
 
@@ -388,5 +395,6 @@ func TestWriteMessage(t *testing.T) {
 
   err = testSumoLogger.writeMessage(&testLogsBatch, testLogs)
   assert.Nil(t, err, "should be no error when writing logs")
-  assert.Equal(t, testLogCount * (len(testLog.line) + len([]byte("\n"))), testLogsBatch.Len(), "all logs should be written to the writer")
+  assert.Equal(t, testLogCount * (len(testLog.line) + len([]byte("\n"))), testLogsBatch.Len(),
+    "all logs should be written to the writer")
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -68,7 +68,7 @@ func TestConsumeLogsFromFile(t *testing.T) {
 
   enc := logdriver.NewLogEntryEncoder(inputFile)
 
-  t.Run("logCount=1", func(t *testing.T) {
+  t.Run("testLogCount=1", func(t *testing.T) {
     enc.Encode(testLogMessage)
     consumedLog := <-testSumoLogger.logQueue
     assert.Equal(t, testSource, consumedLog.source, "should read the correct log source")
@@ -76,7 +76,7 @@ func TestConsumeLogsFromFile(t *testing.T) {
     assert.Equal(t, testIsPartial, consumedLog.isPartial, "should read the correct log partial")
   })
 
-  t.Run("logCount=100000", func(t *testing.T) {
+  t.Run("testLogCount=100000", func(t *testing.T) {
     testLogsCount := 100000
     go func() {
       for i := 0; i < testLogsCount; i++ {
@@ -117,7 +117,7 @@ func TestBatchLogs(t *testing.T) {
     assert.Equal(t, 0, len(testLogBatchQueue), "should have dropped the log for being too large")
   })
 
-  t.Run("batchSize=200 bytes, logCount=1", func(t *testing.T) {
+  t.Run("batchSize=200 bytes, testLogCount=1", func(t *testing.T) {
     testBatchSize := 200
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
     testLogBatchQueue := make(chan []*sumoLog, defaultQueueSizeItems)
@@ -137,7 +137,7 @@ func TestBatchLogs(t *testing.T) {
     assert.Equal(t, 0, len(testLogBatchQueue), "should have emptied out the batch queue")
   })
 
-  t.Run("batchSize=200 bytes, logCount=100000", func(t *testing.T) {
+  t.Run("batchSize=200 bytes, testLogCount=100000", func(t *testing.T) {
     testBatchSize := 200
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
     testLogBatchQueue := make(chan []*sumoLog, defaultQueueSizeItems)
@@ -150,13 +150,13 @@ func TestBatchLogs(t *testing.T) {
     }
     go testSumoLogger.batchLogs()
 
-    logCount := 100000
+    testLogCount := 100000
     go func() {
-      for i := 0; i < logCount; i++ {
+      for i := 0; i < testLogCount; i++ {
         testLogQueue <- testSumoLog
       }
     }()
-    for i := 0; i < logCount / (testBatchSize / len(testLine)); i++ {
+    for i := 0; i < testLogCount / (testBatchSize / len(testLine)); i++ {
       testLogBatch := <-testLogBatchQueue
       assert.Equal(t, testBatchSize / len(testLine), len(testLogBatch),
         "should have correct number of logs in a batch")
@@ -165,7 +165,7 @@ func TestBatchLogs(t *testing.T) {
     assert.Equal(t, 0, len(testLogBatchQueue), "should have emptied out the batch queue")
   })
 
-  t.Run("batchSize=2000000 bytes, logCount=1", func(t *testing.T) {
+  t.Run("batchSize=2000000 bytes, testLogCount=1", func(t *testing.T) {
     testBatchSize := 2000000
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
     testLogBatchQueue := make(chan []*sumoLog, defaultQueueSizeItems)
@@ -185,7 +185,7 @@ func TestBatchLogs(t *testing.T) {
     assert.Equal(t, 0, len(testLogBatchQueue), "should have emptied out the batch queue")
   })
 
-  t.Run("batchSize=2000000 bytes, logCount=1000000", func(t *testing.T) {
+  t.Run("batchSize=2000000 bytes, testLogCount=1000000", func(t *testing.T) {
     testBatchSize := 2000000
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
     testLogBatchQueue := make(chan []*sumoLog, defaultQueueSizeItems)
@@ -198,13 +198,13 @@ func TestBatchLogs(t *testing.T) {
     }
     go testSumoLogger.batchLogs()
 
-    logCount := 1000000
+    testLogCount := 1000000
     go func() {
-      for i := 0; i < logCount; i++ {
+      for i := 0; i < testLogCount; i++ {
         testLogQueue <- testSumoLog
       }
     }()
-    for i := 0; i < logCount / (testBatchSize / len(testLine)); i++ {
+    for i := 0; i < testLogCount / (testBatchSize / len(testLine)); i++ {
       testLogBatch := <-testLogBatchQueue
       assert.Equal(t, testBatchSize / len(testLine), len(testLogBatch),
         "should have correct number of logs in a batch")
@@ -242,7 +242,7 @@ func TestHandleBatchedLogs(t *testing.T) {
 func TestSendLogs(t *testing.T) {
   testLogBatchQueue := make(chan []*sumoLog, 4000)
 
-  t.Run("logCount=1, status=OK", func(t *testing.T) {
+  t.Run("testLogCount=1, status=OK", func(t *testing.T) {
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
@@ -265,15 +265,15 @@ func TestSendLogs(t *testing.T) {
     assert.Equal(t, 1, testClient.requestCount, "should have received one request")
   })
 
-  t.Run("logCount=100000, status=OK", func(t *testing.T) {
-    logCount := 100000
+  t.Run("testLogCount=100000, status=OK", func(t *testing.T) {
+    testLogCount := 100000
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
       line: testLine,
       isPartial: testIsPartial,
     }
-    for i := 0; i < logCount; i++ {
+    for i := 0; i < testLogCount; i++ {
       testLogs = append(testLogs, testLog)
     }
 
@@ -291,7 +291,7 @@ func TestSendLogs(t *testing.T) {
     assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
   })
 
-  t.Run("logCount=1, status=BadRequest", func(t *testing.T) {
+  t.Run("testLogCount=1, status=BadRequest", func(t *testing.T) {
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
@@ -314,15 +314,15 @@ func TestSendLogs(t *testing.T) {
     assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
   })
 
-  t.Run("logCount=100000, status=BadRequest", func(t *testing.T) {
-    logCount := 100000
+  t.Run("testLogCount=100000, status=BadRequest", func(t *testing.T) {
+    testLogCount := 100000
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
       line: testLine,
       isPartial: testIsPartial,
     }
-    for i := 0; i < logCount; i++ {
+    for i := 0; i < testLogCount; i++ {
       testLogs = append(testLogs, testLog)
     }
 
@@ -357,12 +357,12 @@ func TestWriteMessage(t *testing.T) {
   assert.Nil(t, err, "should be no error when writing no logs")
   assert.Equal(t, 0, testLogsBatch.Len(), "nothing should be written to the writer")
 
-  logCount := 100000
-  for i := 0; i < logCount; i++ {
+  testLogCount := 100000
+  for i := 0; i < testLogCount; i++ {
     testLogs = append(testLogs, testLog)
   }
 
   err = testSumoLogger.writeMessage(&testLogsBatch, testLogs)
   assert.Nil(t, err, "should be no error when writing logs")
-  assert.Equal(t, logCount * (len(testLog.line) + len([]byte("\n"))), testLogsBatch.Len(), "all logs should be written to the writer")
+  assert.Equal(t, testLogCount * (len(testLog.line) + len([]byte("\n"))), testLogsBatch.Len(), "all logs should be written to the writer")
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -265,8 +265,8 @@ func TestSendLogs(t *testing.T) {
     assert.Equal(t, 1, testClient.requestCount, "should have received one request")
   })
 
-  t.Run("logCount=1000, status=OK", func(t *testing.T) {
-    logCount := 1000
+  t.Run("logCount=100000, status=OK", func(t *testing.T) {
+    logCount := 100000
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
@@ -314,8 +314,8 @@ func TestSendLogs(t *testing.T) {
     assert.Equal(t, 1, testClient.requestCount, "should have received one request, logs are batched")
   })
 
-  t.Run("logCount=1000, status=BadRequest", func(t *testing.T) {
-    logCount := 1000
+  t.Run("logCount=100000, status=BadRequest", func(t *testing.T) {
+    logCount := 100000
     var testLogs []*sumoLog
     testLog := &sumoLog{
       source: testSource,
@@ -357,7 +357,7 @@ func TestWriteMessage(t *testing.T) {
   assert.Nil(t, err, "should be no error when writing no logs")
   assert.Equal(t, 0, testLogsBatch.Len(), "nothing should be written to the writer")
 
-  logCount := 100
+  logCount := 100000
   for i := 0; i < logCount; i++ {
     testLogs = append(testLogs, testLog)
   }

--- a/logger_test.go
+++ b/logger_test.go
@@ -113,23 +113,6 @@ func TestBatchLogs(t *testing.T) {
     testLogQueue <- testSumoLog
     time.Sleep(500 * time.Millisecond)
     assert.Equal(t, 0, len(testLogBatchQueue), "should have dropped the log for being too large")
-
-    // testLogBatch := <-testLogBatchQueue
-    // assert.Equal(t, 1, len(testLogBatch), "should have received one batch from single log")
-    // assert.Equal(t, testLine, testLogBatch[0].line, "should have received the correct log")
-    //
-    // testLogCount := 1000
-    // go func() {
-    //   for i := 0; i < testLogCount; i++ {
-    //     testLogQueue <- testSumoLog
-    //   }
-    // }()
-    // go func(t *testing.T) {
-    //   for i := 0; i < testLogCount; i++ {
-    //     <-testLogBatchQueue
-    //   }
-    //   assert.Equal(t, 0, len(testLogBatchQueue), "should have emptied out the batch queue")
-    // }(t)
   })
 
   t.Run("batchSize=18 bytes", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -11,8 +11,7 @@ import (
 
 const (
   // if you change the name here, don't forget to change it in config.json
-  pluginName = "sumo-log-driver"
-  logOptUrl = "sumo-url"
+  pluginName = "sumologic"
   startLoggingPath = "/LogDriver.StartLogging"
   stopLoggingPath = "/LogDriver.StopLogging"
 )


### PR DESCRIPTION
## Summary
This PR is to update the logic for batching and sending logs to ensure there is never any back-pressuring to the file, and therefore the docker container

# main.go
The logging-driver plugin is an HTTP server that handles three requests from the Docker daemon: `/Plugin.Activate`, `/LogDriver.StartLogging` and `/LogDriver.StopLogging`. These handlers are implemented in `main.go`.

### /Plugin.Activate
The `/Plugin.Activate` handler is implemented via an API provided by Docker (line 20). Upon plugin installation, the Docker daemon makes a request to this endpoint and receives a response of this form:
```json
{
    "Implements": ["LoggingDriver"]
}
```
This tells the Docker daemon that the plugin is a logging-driver, and to a customer, our plugin now behaves exactly like any native logging-driver.

### /LogDriver.StartLogging, /LogDriver.StopLogging
The logging-driver plugin has one main component, the ***driver*** (line 22). There is one driver per Docker daemon. The driver has only one job: to create and delete individual ***loggers***. There is one logger per Docker container.

When a customer starts a Docker container with our logging-driver plugin, the Docker daemon makes a request to the `/LogDriver.StartLogging` endpoint with the necessary information needed for the driver to create a corresponding logger. Similarly, when a customer shuts down a Docker container running our logging-driver plugin, the Docker daemon makes a request to the `/LogDriver.StopLogging` endpoint, and the driver finds and removes the corresponding logger. The handlers for these request endpoints begin on lines 47 and 67, and are initialized on line 23.

# driver.go
The driver is required to have two methods: `StartLogging` and `StopLogging`, called when the respective requests are made to the plugin.

### StartLogging
`StartLogging` (line 103) takes the information provided by the Docker daemon to create a logger for the container. It then starts three goroutines (like threads, but smaller; see [here]). We will explain these goroutines in `logger.go`.

[here]: https://golang.org/doc/faq#goroutines

### StopLogging
`StopLogging` (line 180) does cleanup and deletes the logger.

Creating and deleting of loggers is protected by a mutex.

### NewSumoLogger
The third method is `NewSumoLogger` (line 114) which creates the logger with certain configurations.

### parseLogOpt
These helper functions are used to parse the log-opts provided by the customer into usable fields.

# logger.go
There are three goroutines for each logger, each with specified tasks.

### consumeLogsFromFile
The Docker container's logs are sent to the plugin via a protocol buffer FIFO file. Before the Docker daemon makes the request to start logging, it creates this file and gives us the path to this file. The first goroutine reads the encoded logs from the file, decodes them and sends them to the `logQueue`. It is crucial that this goroutine does not get blocked from reading available logs from the file, as this can potentially block the Docker container. If there are no available logs in the file, then `ReadMsg` will block, to prevent the infinite for loop from eating up CPU.

### batchLogs
The second goroutine pops the individual logs from the logQueue and batches them. Once the batch of logs is past a certain batch-size (by default 1 megabyte), the batch is put into the `logBatchQueue`. However, if the batch hasn't reached the batch-size by a specified time (set by sending-interval, by default 2 seconds), the smaller batch is put into the `logBatchQueue`.

It is crucial that this goroutine does not get blocked from pulling available logs from the `logQueue`, as this can back-pressure back to the first goroutine. As a result, if the `logBatchQueue` is filling up due to failures in the third goroutine, we will drop the oldest batch so that we never block the Docker container.

All of the pushing to the `logBatchQueue` and dropping logic is handled in `pushBatchToQueue`.

### handleBatchedLogs
The third goroutine pops the log batches from the `logBatchQueue`, and makes the POST request to the SumoLogic HTTP source via the provided url. If there is a network failure of any kind and the request fails, then we retry at a set interval (5 seconds) until the request succeeds. Since making the HTTP request could potentially take a long time, this goroutine may block.

All of the POST request logic is handled in `sendLogs`.