### PR TITLE
SUMO-100899 fix file already closed, and flaky UT

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,8 @@ import (
   "io/ioutil"
   "math"
   "net/http"
+  "os"
+  "strings"
   "time"
 
   "github.com/docker/docker/api/types/plugins/logdriver"
@@ -57,7 +59,7 @@ func (sumoLogger *sumoLogger) consumeLogsFromFile() {
   var log logdriver.LogEntry
   for {
     if err := dec.ReadMsg(&log); err != nil {
-      if err == io.EOF {
+      if err == io.EOF || err == os.ErrClosed || strings.Contains(err.Error(), "file already closed") {
         sumoLogger.inputFile.Close()
         close(sumoLogger.logQueue)
         return

--- a/logger_test.go
+++ b/logger_test.go
@@ -121,7 +121,7 @@ func TestBatchLogs(t *testing.T) {
   t.Run("batchSize=200 bytes, testLogCount=1", func(t *testing.T) {
     testBatchSize := 200
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
-    testLogBatchQueue := make(chan *sumoLogBatch, defaultQueueSizeItems)
+    testLogBatchQueue := make(chan *sumoLogBatch, 10 * defaultQueueSizeItems)
     testSumoLogger := &sumoLogger{
       httpSourceUrl: testHttpSourceUrl,
       logQueue: testLogQueue,
@@ -140,8 +140,8 @@ func TestBatchLogs(t *testing.T) {
 
   t.Run("batchSize=200 bytes, testLogCount=100000", func(t *testing.T) {
     testBatchSize := 200
-    testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
-    testLogBatchQueue := make(chan *sumoLogBatch, defaultQueueSizeItems)
+    testLogQueue := make(chan *sumoLog, 1000 * defaultQueueSizeItems)
+    testLogBatchQueue := make(chan *sumoLogBatch, 100 * defaultQueueSizeItems)
     testSumoLogger := &sumoLogger{
       httpSourceUrl: testHttpSourceUrl,
       logQueue: testLogQueue,
@@ -169,7 +169,7 @@ func TestBatchLogs(t *testing.T) {
   t.Run("batchSize=2000000 bytes, testLogCount=1", func(t *testing.T) {
     testBatchSize := 2000000
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
-    testLogBatchQueue := make(chan *sumoLogBatch, defaultQueueSizeItems)
+    testLogBatchQueue := make(chan *sumoLogBatch, 10 * defaultQueueSizeItems)
     testSumoLogger := &sumoLogger{
       httpSourceUrl: testHttpSourceUrl,
       logQueue: testLogQueue,
@@ -189,7 +189,7 @@ func TestBatchLogs(t *testing.T) {
   t.Run("batchSize=2000000 bytes, testLogCount=1000000", func(t *testing.T) {
     testBatchSize := 2000000
     testLogQueue := make(chan *sumoLog, 100 * defaultQueueSizeItems)
-    testLogBatchQueue := make(chan *sumoLogBatch, defaultQueueSizeItems)
+    testLogBatchQueue := make(chan *sumoLogBatch, 10 * defaultQueueSizeItems)
     testSumoLogger := &sumoLogger{
       httpSourceUrl: testHttpSourceUrl,
       logQueue: testLogQueue,


### PR DESCRIPTION
https://jira.kumoroku.com/jira/browse/SUMO-100899

There was a race condition - the infinite for loop in `consumeLogsFromFile` in `logger.go` was trying to read from the file, but since the file was already closed by `StopLogging` in `driver.go`, the read attempt was returning a `file already closed` error.

We would then log that error and retry infinitely, which was causing disk space to fill up.

I've added the necessary checks to ensure that we break out of the infinite for loop in the event of the file being closed. I've also fixed some flaky UT's that weren't passing because the test queues were filling up too quickly, maybe because computer is too fast? Not sure 🤔