### PR TITLE
Rename sending-frequency to sending-interval in README and shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ docker run --log-driver=sumologic \
     --log-opt sumo-url=sumo-source-url \
     --log-opt sumo-batch-size=2000000 \
     --log-opt sumo-queue-size=400 \
-    --log-opt sumo-sending-frequency=500ms \
+    --log-opt sumo-sending-interval=2000ms \
     --log-opt sumo-compress=false \
     --log-opt ... \
     your_container

--- a/certificate/run_sumologic_driver.sh
+++ b/certificate/run_sumologic_driver.sh
@@ -4,7 +4,7 @@ docker container run --rm --log-driver=store/sumologic/docker-logging-driver:1.0
     --log-opt tag={{.ID}} \
     --log-opt sumo-batch-size=2000000 \
     --log-opt sumo-queue-size=400 \
-    --log-opt sumo-sending-frequency=500ms \
+    --log-opt sumo-sending-interval=2000ms \
     --log-opt sumo-compress=false \
     --volume $(pwd)/quotes.txt:/quotes.txt alpine:latest \
     sh -c 'cat /quotes.txt;sleep 10'


### PR DESCRIPTION
We incorrectly had `sumo-sending-frequency` in our README example and in our shell script. I've fixed these to be the correct log-opt, `sumo-sending-interval`.

I've also updated the value from 500ms to 2000ms. This is for consistency: the default value in the code is currently set to 2000ms, which means that anybody who was using the `run_sumologic_driver.sh` script was using the default value of 2000ms.