### PR TITLE
change info logs to debug logs

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -226,7 +226,7 @@ func (sumoDriver *sumoDriver) StopLogging(file string) error {
   sumoDriver.mu.Lock()
   sumoLogger, exists := sumoDriver.loggers[file]
   if exists {
-    logrus.Info(fmt.Sprintf("%s: Stopping logging driver for closed container.", pluginName))
+    logrus.Debug(fmt.Sprintf("%s: Stopping logging driver for closed container.", pluginName))
     sumoLogger.inputFile.Close()
     delete(sumoDriver.loggers, file)
   }

--- a/logger.go
+++ b/logger.go
@@ -127,14 +127,14 @@ func (sumoLogger *sumoLogger) handleBatchedLogs() {
       return
     }
     for {
-      logrus.Info(fmt.Sprintf("%s: Sending logs batch. batch-size: %d bytes",
+      logrus.Debug(fmt.Sprintf("%s: Sending logs batch. batch-size: %d bytes",
         pluginName, logBatch.sizeBytes))
       err := sumoLogger.sendLogs(logBatch.logs)
       if err == nil {
         retryInterval = initialRetryInterval
         break
       }
-      logrus.Info(fmt.Sprintf("%s: Sleeping for %s before retry...",
+      logrus.Debug(fmt.Sprintf("%s: Sleeping for %s before retry...",
         pluginName, retryInterval.String()))
       time.Sleep(retryInterval)
       if retryInterval < maxRetryInterval {


### PR DESCRIPTION
Based on the concern brought up here: https://github.com/SumoLogic/sumologic-docker-logging-driver/issues/33

It seems that any logs emitted by the logging driver itself get collected by dockerd as an error log. I spent some time trying to figure out why this is the case but couldn't.

Since these noisy `INFO` logs are the primary concern here, I'm proposing we just remove them. I don't feel they add much value outside of a debugging scenario anyway.

