### PR TITLE
upgrade base golang docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # From https://github.com/jahkeup/updater53/blob/master/Dockerfile
 ###############################################################################
 
-FROM  golang:1.8 as builder
+FROM golang:1.14.6-alpine3.12 as builder
 
 WORKDIR /go/src/github.com/SumoLogic/docker-logging-driver
 COPY . .
@@ -10,7 +10,9 @@ ARG GOOS=linux
 ARG GOARCH=amd64
 ARG GOARM=
 
-RUN go get -d -v ./...
+RUN apk add --no-cache git mercurial \
+    && go get -d -v ./... \
+    && apk del git mercurial
 RUN CGO_ENABLED=0 go build -v -a -installsuffix cgo -o docker-logging-driver
 
 ###############################################################################


### PR DESCRIPTION
Unfortunately the golang base docker image is outdated and we can't build the image anymore due to certain dependencies not working. We'll have to upgrade the image, but the base golang docker image no longer includes git so we need to include it while getting dependencies.