### PR TITLE
Update README for arm64 & deprecated repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ In this step you create, on the Sumo service, an HTTP endpoint to receive your D
 
 On each Docker host with containers from which you want to collect container logs, install the plugin by running the following command in a terminal window:
 ```bash
-$ docker plugin install store/sumologic/docker-logging-driver:1.0.5 --alias sumologic --grant-all-permissions
+$ docker plugin install sumologic/docker-logging-driver:1.0.5 --alias sumologic --grant-all-permissions
+```
+This defaults to amd64; for arm64, please pull the corresponding version:
+```bash
+$ docker plugin install sumologic/docker-logging-driver:1.0.5-arm64 --alias sumologic --grant-all-permissions
 ```
 
 **NOTE** The `--alias` is required for using it on AWS ECS
+
+**NOTE** As of version `1.0.5`, the Docker Publisher Center is retired, and as such we host our own images. Please pull from `sumologic/docker-logging-driver` instead of `store/sumologic/docker-logging-driver` moving forward.
 
 To verify that the plugin is installed and enabled, run the following command:
 


### PR DESCRIPTION
Adds `arm64` support to the README

Adds note about deprecated `store/sumologic/docker-logging-driver` repo